### PR TITLE
Support OpenVPN 2.6.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache \
     unzip=6.0-r14
 
 # Patch & build OpenVPN
-ARG OPENVPN_VERSION=2.6.3
+ARG OPENVPN_VERSION=2.6.8
 
 RUN curl -L "https://github.com/OpenVPN/openvpn/archive/v${OPENVPN_VERSION}.zip" -o openvpn.zip \
     && unzip openvpn.zip \
@@ -59,7 +59,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Patch & build OpenVPN
-ARG OPENVPN_VERSION=2.6.3
+ARG OPENVPN_VERSION=2.6.8
 
 RUN curl -L "https://github.com/OpenVPN/openvpn/archive/v${OPENVPN_VERSION}.zip" -o openvpn.zip \
     && unzip openvpn.zip \

--- a/patches/openvpn-v2.6.8-aws.patch
+++ b/patches/openvpn-v2.6.8-aws.patch
@@ -1,0 +1,133 @@
+diff --git a/src/openvpn/buffer.h b/src/openvpn/buffer.h
+index 4cc79507..9f1060cc 100644
+--- a/src/openvpn/buffer.h
++++ b/src/openvpn/buffer.h
+@@ -27,7 +27,7 @@
+ #include "basic.h"
+ #include "error.h"
+ 
+-#define BUF_SIZE_MAX 1000000
++#define BUF_SIZE_MAX 1 << 21
+ 
+ /*
+  * Define verify_align function, otherwise
+diff --git a/src/openvpn/common.h b/src/openvpn/common.h
+index f77685c8..4ccc5d2d 100644
+--- a/src/openvpn/common.h
++++ b/src/openvpn/common.h
+@@ -66,7 +66,7 @@ typedef unsigned long ptr_type;
+  * maximum size of a single TLS message (cleartext).
+  * This parameter must be >= PUSH_BUNDLE_SIZE
+  */
+-#define TLS_CHANNEL_BUF_SIZE 2048
++#define TLS_CHANNEL_BUF_SIZE 1 << 18
+ 
+ /* TLS control buffer minimum size
+  *
+diff --git a/src/openvpn/error.h b/src/openvpn/error.h
+index 1225b139..7fe7816b 100644
+--- a/src/openvpn/error.h
++++ b/src/openvpn/error.h
+@@ -40,7 +40,10 @@
+ #if defined(ENABLE_PKCS11) || defined(ENABLE_MANAGEMENT)
+ #define ERR_BUF_SIZE 10240
+ #else
+-#define ERR_BUF_SIZE 1280
++/*
++ * Increase the error buffer size to 256 KB.
++ */
++#define ERR_BUF_SIZE 1 << 18
+ #endif
+ 
+ struct gc_arena;
+diff --git a/src/openvpn/manage.c b/src/openvpn/manage.c
+index 739ed40f..195eb592 100644
+--- a/src/openvpn/manage.c
++++ b/src/openvpn/manage.c
+@@ -2245,7 +2245,7 @@ man_read(struct management *man)
+     /*
+      * read command line from socket
+      */
+-    unsigned char buf[256];
++    unsigned char buf[MANAGEMENT_SOCKET_READ_BUFFER_SIZE];
+     int len = 0;
+ 
+ #ifdef TARGET_ANDROID
+diff --git a/src/openvpn/manage.h b/src/openvpn/manage.h
+index 07317a40..7fcb5277 100644
+--- a/src/openvpn/manage.h
++++ b/src/openvpn/manage.h
+@@ -58,6 +58,9 @@
+ #define MANAGEMENT_ECHO_BUFFER_SIZE           100
+ #define MANAGEMENT_STATE_BUFFER_SIZE          100
+ 
++#define COMMAND_LINE_OPTION_BUFFER_SIZE OPTION_PARM_SIZE
++#define MANAGEMENT_SOCKET_READ_BUFFER_SIZE OPTION_PARM_SIZE
++
+ /*
+  * Management-interface-based deferred authentication
+  */
+diff --git a/src/openvpn/misc.h b/src/openvpn/misc.h
+index b000b729..675a1b9a 100644
+--- a/src/openvpn/misc.h
++++ b/src/openvpn/misc.h
+@@ -65,7 +65,10 @@ struct user_pass
+ #ifdef ENABLE_PKCS11
+ #define USER_PASS_LEN 4096
+ #else
+-#define USER_PASS_LEN 128
++/*
++ * Increase the username and password length size to 128KB.
++ */
++#define USER_PASS_LEN 1 << 17
+ #endif
+     /* Note that username and password are expected to be null-terminated */
+     char username[USER_PASS_LEN];
+diff --git a/src/openvpn/options.h b/src/openvpn/options.h
+index f5890b90..ca00c6eb 100644
+--- a/src/openvpn/options.h
++++ b/src/openvpn/options.h
+@@ -54,8 +54,8 @@
+ /*
+  * Max size of options line and parameter.
+  */
+-#define OPTION_PARM_SIZE 256
+-#define OPTION_LINE_SIZE 256
++#define OPTION_PARM_SIZE USER_PASS_LEN
++#define OPTION_LINE_SIZE OPTION_PARM_SIZE
+ 
+ extern const char title_string[];
+ 
+diff --git a/src/openvpn/ssl.c b/src/openvpn/ssl.c
+index 12bc85f9..b202e4a7 100644
+--- a/src/openvpn/ssl.c
++++ b/src/openvpn/ssl.c
+@@ -1929,7 +1929,7 @@ tls_session_soft_reset(struct tls_multi *tls_multi)
+ static bool
+ write_empty_string(struct buffer *buf)
+ {
+-    if (!buf_write_u16(buf, 0))
++    if (!buf_write_u32(buf, 0))
+     {
+         return false;
+     }
+@@ -1944,7 +1944,7 @@ write_string(struct buffer *buf, const char *str, const int maxlen)
+     {
+         return false;
+     }
+-    if (!buf_write_u16(buf, len))
++    if (!buf_write_u32(buf, len))
+     {
+         return false;
+     }
+@@ -2284,6 +2284,10 @@ key_method_2_write(struct buffer *buf, struct tls_multi *multi, struct tls_sessi
+         p2p_mode_ncp(multi, session);
+     }
+ 
++    // Write key length in the first 4 octets of the buffer.
++    uint32_t length = BLEN(buf);
++    memcpy(buf->data, &length, sizeof(length));
++
+     return true;
+ 
+ error:


### PR DESCRIPTION
- [x] Add `openvpn-v2.6.8-aws.patch`
- [x] Use `2.6.8` by default for `make`